### PR TITLE
Rework: Commands benutzen Commands extension

### DIFF
--- a/PrincessPaperplane/discordBot.py
+++ b/PrincessPaperplane/discordBot.py
@@ -353,8 +353,9 @@ async def cmd_rank(ctx: commands.Context, member: typing.Optional[discord.Member
     db = dbConnect()
     cur = db.cursor()
     db.autocommit(True)
-
-    cur.execute("SELECT exp, level, name FROM user_info WHERE id = %s", (author.id,))
+    
+    if server.id == LIVE_SERVER:
+        cur.execute("SELECT exp, level, name FROM user_info WHERE id = %s", (author.id,))
     if server.id == TEST_SERVER:
         cur.execute("SELECT exp, level, name FROM user_info_test WHERE id = %s", (author.id,))
     row = cur.fetchone()

--- a/PrincessPaperplane/discordBot.py
+++ b/PrincessPaperplane/discordBot.py
@@ -353,7 +353,7 @@ async def cmd_rank(ctx: commands.Context, member: typing.Optional[discord.Member
     db = dbConnect()
     cur = db.cursor()
     db.autocommit(True)
-    
+
     if server.id == LIVE_SERVER:
         cur.execute("SELECT exp, level, name FROM user_info WHERE id = %s", (author.id,))
     if server.id == TEST_SERVER:

--- a/PrincessPaperplane/discordBot.py
+++ b/PrincessPaperplane/discordBot.py
@@ -325,10 +325,12 @@ async def on_message(message):
     await bot.process_commands(message)
 
 #Used as decorator
-def is_allowed_command_channel():
+def is_in_channel(channel_id : int):
+    """Used as decorator that checks if bot can post in this channel
+    """
     #Define predicate to be checked
     async def predicate(ctx):
-        if ctx.server.id == LIVE_SERVER and ctx.channel.id != 760861542735806485: # only allow !rank / !rang in #bod_spam
+        if ctx.server.id == LIVE_SERVER and ctx.channel.id != channel_id: # only allow !rank / !rang in #bod_spam
             return False
         else:
             return True
@@ -336,8 +338,14 @@ def is_allowed_command_channel():
     return commands.check(predicate)
 
 @commands.command(aliases=['rank', 'rang'])
-@is_allowed_command_channel()
-async def cmd_rank(ctx : commands.Context, member : typing.Optional[discord.Member]):
+@is_in_channel(760861542735806485) 
+async def cmd_rank(ctx: commands.Context, member: typing.Optional[discord.Member]):
+    """Handles rank command
+
+    Args:
+        ctx (commands.Context): [description]
+        member (typing.Optional[discord.Member]): Member argument
+    """
     channel = ctx.channel
     server = ctx.guild
     author = ctx.author


### PR DESCRIPTION
### Warum?
- Übersichtlicher und leichter zu erweitern (finde ich)
- Einfacherer umgang mit Command Arguments und Checks (User Permission, Cooldowns, etc.)

### Allgemein
- Commands in Methods gepackt und mit @bot.command() decorator versehen
- In `on_message()` wird am Ende `await bot.process_commands(message)` aufgerufen, um die Message an das Command handling weiterzugeben
- Parameter sind jetzt zuständig für auslesen der Argumente eines Commands
   - z.B.: Anstatt `message.content[i]` auszulesen und zu checken, werden die gewünschten Argumente in der Nachricht direkt in den Parametern verarbeitet und bereitgestellt: `async def cmd_foo(ctx, arg1: int, arg2: int, *list_of_args_of_type : discord.Member)`

### Command; Rank
- Check für #bod_spam channel in decorator `@is_in_channel` gepackt
- Baut nun seperate Verbindung zur DB auf (nutzt nicht mehr die vom XP hinzufügen)

### Command W (Dice)
- Bisschen angepasst, anstatt `x` jetzt Leerzeichen für Trennung von Würfel und Anzahl
    - War mir nicht sicher ob das genau so sein sollte, oder einfach nur so implementiert worden ist mit dem x
- Argumente `dice` und `mulitply` stehen jetzt direkt in den Parametern zur Verfügung
    - Hab multiply zu amount umbennant (kein spezieller Grund dahinter 😅)
- Zweites Parameter für Anzahl von Würfen ist optional, ist 1 wenn nicht gegeben
- In on_message() wird der Content der Message bisschen verändert, sodass das Command abgefangen wird
    - z.B.: !w6 2 -> !w 6 2 (geht auch mit d anstatt w)
    - Benutzt Regex Pattern Matching um Command zu filtern (mit `re`)

### Achtung!
- Konnte nur Teile testen
   - Dice ✔️
       - Pattern matching und message.content verändern ✔️ 
   - Rank (nur check für richtige channel id) ✔️ 
       - DB sachen nicht getestet ❌ 
 - Muss noch einmal ganz durchlaufen, könnten sich Fehler eingeschlichen haben

@the501legion 