### PR TITLE
Add HowLongToBeat feature for discord

### DIFF
--- a/PrincessPaperplane/ext/__init__.py
+++ b/PrincessPaperplane/ext/__init__.py
@@ -9,3 +9,4 @@ HTTP_CODES = {
 def load_extensions(bot):
     bot.load_extension("ext.twitter_crawler")
     bot.load_extension("ext.wool_cmd")
+    bot.load_extension("ext.hltb")

--- a/PrincessPaperplane/ext/hltb/__init__.py
+++ b/PrincessPaperplane/ext/hltb/__init__.py
@@ -1,0 +1,6 @@
+from discord.ext.commands import Bot
+from .hltb import HLTB
+
+
+def setup(bot: Bot):
+    bot.add_cog(HLTB(bot))

--- a/PrincessPaperplane/ext/hltb/hltb.py
+++ b/PrincessPaperplane/ext/hltb/hltb.py
@@ -1,0 +1,28 @@
+from discord import Embed
+from discord.ext import commands
+from discord.ext.commands import Cog, Bot
+from howlongtobeatpy import HowLongToBeat, HowLongToBeatEntry
+
+
+class HLTB(Cog):
+    def __init__(self, bot: Bot):
+        self.bot = bot
+
+    @commands.command('hltb')
+    async def hltb(self, ctx: commands.Context, *, game: str):
+        result_list = await HowLongToBeat().async_search(game)
+        if result_list is not None and len(result_list) > 0:
+            g: HowLongToBeatEntry = max(result_list, key=lambda element: element.similarity)
+
+            embeded = Embed(title=g.game_name)
+            embeded.set_author(name="How Long To Beat", url="https://howlongtobeat.com/")
+            embeded.add_field(name="Main Story", value=f"{g.gameplay_main} {g.gameplay_main_unit}")
+            embeded.add_field(name="Story + Extras", value=f"{g.gameplay_main_extra} {g.gameplay_main_extra_unit}")
+            embeded.add_field(name="Completionist", value=f"{g.gameplay_completionist} {g.gameplay_completionist_unit}")
+
+            embeded.add_field(name="Link", value=g.game_web_link)
+            embeded.set_thumbnail(url=f"https://howlongtobeat.com{g.game_image_url}")
+
+            return await ctx.channel.send(embed=embeded)
+
+        return await ctx.channel.send(f"No results for {game} :(")

--- a/PrincessPaperplane/ext/hltb/hltb.py
+++ b/PrincessPaperplane/ext/hltb/hltb.py
@@ -8,9 +8,9 @@ class HLTB(Cog):
     def __init__(self, bot: Bot):
         self.bot = bot
 
-    @commands.command(name='hltb', aliases=['hl', 'howlong', 'howlongtobeat'])
+    @commands.command(name='hltb', aliases=['hl', 'howlong', 'howlongtobeat'], help="Lookup estimated playtime for a game")
     async def hltb(self, ctx: commands.Context, *, game: str):
-        result_list = await HowLongToBeat().async_search(game)
+        result_list = await HowLongToBeat(0.0).async_search(game, similarity_case_sensitive=False)
         if result_list is not None and len(result_list) > 0:
             g: HowLongToBeatEntry = max(result_list, key=lambda element: element.similarity)
 

--- a/PrincessPaperplane/ext/hltb/hltb.py
+++ b/PrincessPaperplane/ext/hltb/hltb.py
@@ -8,21 +8,21 @@ class HLTB(Cog):
     def __init__(self, bot: Bot):
         self.bot = bot
 
-    @commands.command('hltb')
+    @commands.command(name='hltb', aliases=['hl', 'howlong', 'howlongtobeat'])
     async def hltb(self, ctx: commands.Context, *, game: str):
         result_list = await HowLongToBeat().async_search(game)
         if result_list is not None and len(result_list) > 0:
             g: HowLongToBeatEntry = max(result_list, key=lambda element: element.similarity)
 
-            embeded = Embed(title=g.game_name)
-            embeded.set_author(name="How Long To Beat", url="https://howlongtobeat.com/")
-            embeded.add_field(name="Main Story", value=f"{g.gameplay_main} {g.gameplay_main_unit}")
-            embeded.add_field(name="Story + Extras", value=f"{g.gameplay_main_extra} {g.gameplay_main_extra_unit}")
-            embeded.add_field(name="Completionist", value=f"{g.gameplay_completionist} {g.gameplay_completionist_unit}")
+            embed = Embed(title=g.game_name)
+            embed.set_author(name="How Long To Beat", url="https://howlongtobeat.com/")
+            embed.add_field(name="Main Story", value=f"{g.gameplay_main} {g.gameplay_main_unit}")
+            embed.add_field(name="Story + Extras", value=f"{g.gameplay_main_extra} {g.gameplay_main_extra_unit}")
+            embed.add_field(name="Completionist", value=f"{g.gameplay_completionist} {g.gameplay_completionist_unit}")
 
-            embeded.add_field(name="Link", value=g.game_web_link)
-            embeded.set_thumbnail(url=f"https://howlongtobeat.com{g.game_image_url}")
+            embed.add_field(name="Link", value=g.game_web_link)
+            embed.set_thumbnail(url=f"https://howlongtobeat.com{g.game_image_url}")
 
-            return await ctx.channel.send(embed=embeded)
+            return await ctx.channel.send(embed=embed)
 
         return await ctx.channel.send(f"No results for {game} :(")


### PR DESCRIPTION
Quick and hacky HLTB integration into discord, but fully functional.
Needs testing though, because this version of the bot won't start on my system. Don#t know why.
Edit: Needs pip package howlongtobeatpy~=0.1.18

Usage: !hltb `game`

Result looks like this:
![hltb](https://user-images.githubusercontent.com/5995090/132139873-63fb6dd8-ac3a-4672-a9e1-79f3887b8c74.png)
